### PR TITLE
Take BIKESURF_VIRTENV_PATH env variable for virtualenv-wrapper compatibility.

### DIFF
--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -26,7 +26,8 @@ site.addsitedir(os.path.join(PROJECT_DIR, 'env/local/lib/python2.7/site-packages
 sys.path.append(PROJECT_DIR)
 
 # activate virtual env
-activate_env=os.path.expanduser(os.path.join(PROJECT_DIR, "env/bin/activate_this.py"))
+BIKESURF_VIRTENV_PATH = os.environ.get('BIKESURF_VIRTENV_PATH', 'env')
+activate_env=os.path.expanduser(os.path.join(PROJECT_DIR, "{}/bin/activate_this.py".format(BIKESURF_VIRTENV_PATH)))
 execfile(activate_env, dict(__file__=activate_env))
 
 # path to settings file


### PR DESCRIPTION
Hey all,

Instead of hardcoding the 'env' virtualenv, I wanted to set it as follows. The reason why I prefer to do it like this is, I created the virtualenv using virtualenv-wrapper, which is a wrapper over virtualenv commands, and puts all the virtualenvs under ~/.virtualenvs directory. So, In order to run the code, I needed this change. 

Anyone who wants to run the code in that style may add the following line to their bash.rc or zsh.rc or whatever_shell_they_are_using.rc files:

export BIKESURF_VIRTENV_PATH=$HOME/.virtualenvs/bikesurf

(bikesurf is the name of the env)