### PR TITLE
Add missing urls for couchsurfing

### DIFF
--- a/apps/link/models.py
+++ b/apps/link/models.py
@@ -57,6 +57,12 @@ VALID_SITE_URLS = { # TODO better match for each site profile patterns
         "^http://www\.couchsurfing\.org/",
         "^https://couchsurfing\.org/",
         "^https://www\.couchsurfing\.org/",
+        "^couchsurfing\.com/",
+        "^www\.couchsurfing\.com/",
+        "^http://couchsurfing\.com/",
+        "^http://www\.couchsurfing\.com/",
+        "^https://couchsurfing\.com/",
+        "^https://www\.couchsurfing\.com/"
     ],
 }
 

--- a/apps/link/tests.py
+++ b/apps/link/tests.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2012 Fabian Barkhau <fabian.barkhau@gmail.com>
+# License: MIT (see LICENSE.TXT file)
+
+
+"""
+Tests links to external sites
+"""
+
+
+from django.test import TestCase
+from apps.link import control as link_control
+
+class ValidSiteLinks(TestCase):
+    def test_couchsurfing_com_links(self):
+        """
+        Tests that .com urls are accepted
+        """
+        self.assertEqual(True, link_control.valid_profile_format("https://couchsurfing.com/people/deivid_rodriguez", "COUCHSURFING"))
+


### PR DESCRIPTION
Hello! :wave: :wave:

I'm friends with Alberto (Cañi) who contacted bikesurf Berlin to set up "Bikesurf Madrid". I played around with the site a bit today and noticed that I was not able to add my couchsurfing profile link. It's because they're now using `.com` as their main domain instead `.org` (maybe since they switched from non-profit to B-corporation, not sure).

Anyways, I think this should fix it!